### PR TITLE
Added link to a javascript version of Copycat, in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Copycat's architecture is tripartite, consisting of a slipnet, a working area (a
 | [Arthur O'Dwyer](https://github.com/Quuxplusone), [J Alan Brogan](https://github.com/jalanb),others | [Python 2](https://github.com/Quuxplusone/co.py.cat)  | Multiple forks, no graphics  |
 | [Lucas Saldyt](https://github.com/LSaldyt) | [Python 3](https://github.com/LSaldyt/copycat/commit/bc848e8f2d7dd922b96bd0118ba4adf2fc033e55)  | Above repo patch to Python 3  |
 | [Joseph Aaron Hager](https://github.com/ajhager) | [Python 3](https://github.com/ajhager/copycat) | [OpenGL graphics](https://youtu.be/v7Eotp-XKVA) |
+| [Paul Geiger](https://github.com/Paul-G2) | [JavaScript](https://github.com/Paul-G2/copycat-js) | [Demo runs in a browser](https://paul-g2.github.io/copycat-js/) |
+
 
 
 Please see [Mitchell](http://web.cecs.pdx.edu/~mm/)'s [Copycat page](http://web.cecs.pdx.edu/~mm/how-to-get-copycat.html). Scott Boland's re-implementation in Java is 404'ing at The University of Queensland, but it is available [here in this repo](/Software/Copycat/Scott-Boland-implementation%20in%20JAVA/JavaCopycat.zip) and in [archive.org](https://archive.org/details/JavaCopycat).


### PR DESCRIPTION
I'm a few years late to the party, but I've ported Copycat to JavaScript, 
and created a demo that runs in a browser. Please consider linking to it
in your README file. Thanks.