### PR TITLE
Add a link to a JavaScript version of Letter Spirit 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,3 +321,5 @@ John Rehling & [Douglas Hofstadter](http://www.cogs.indiana.edu/people/profile.p
 Find Dr. Rehling in  [Google Scholar](https://scholar.google.com.br/scholar?hl=en&q=john+rehling&btnG=&as_sdt=1%2C5&as_sdtp=).
 
 Dr. Rehling's thesis is available [here](http://goosie.cogsci.indiana.edu/farg/mcgrawg/thesis.html) and his sourcecode is available in the [/Software/Letter-Spirit](/Software/Letter-Spirit) folder.
+
+There's also a javascript version of this project, availble [here](https://github.com/Paul-G2/letter-spirit-2-js).


### PR DESCRIPTION
It didn't feel right to stop after the Examiner project, so I made a demo for the full Letter Spirit 2.
It's available  [here](https://github.com/Paul-G2/letter-spirit-2-js), if you'd like to link to it. 
Thanks!
